### PR TITLE
Remove definition of exact node.js and npm version

### DIFF
--- a/simple-nodejs-application/package.json
+++ b/simple-nodejs-application/package.json
@@ -3,9 +3,5 @@
   "version": "0.0.1",
   "dependencies": {
     "express": "3.4.8"
-  },
-  "engines": {
-    "node": "4.8.2",
-    "npm": "2.7.4"
   }
 }


### PR DESCRIPTION
This will cause the buildpack/app/deployment to use the default version removing the need of maintaining it and causing not working buildpack-update pipeline / victorops alerts.